### PR TITLE
Fix default groups for the homepage

### DIFF
--- a/lib/core/sync/sync_service.dart
+++ b/lib/core/sync/sync_service.dart
@@ -9,7 +9,7 @@ class SyncService {
 
   void startPeriodicSync(VoidCallback callback) {
     _syncTimer?.cancel();
-    _syncTimer = Timer.periodic(const Duration(minutes: 5), (_) {
+    _syncTimer = Timer.periodic(const Duration(minutes: 10), (_) {
       callback();
     });
   }

--- a/lib/data/datasources/onboarding/onboarding_local_data_source.dart
+++ b/lib/data/datasources/onboarding/onboarding_local_data_source.dart
@@ -22,12 +22,6 @@ class OnboardingLocalDataSourceImpl implements OnboardingLocalDataSource {
       KeyConstants.selectedCurrency,
       jsonEncode(model.toJson()),
     );
-    // if (model.selectedCurrency != null) {
-    //   await _preferenceManager.setString(
-    //     KeyConstants.selectedCurrency,
-    //     jsonEncode(model.toJson()),
-    //   );
-    // }
   }
 
   @override

--- a/lib/data/datasources/onboarding/onboarding_local_data_source.dart
+++ b/lib/data/datasources/onboarding/onboarding_local_data_source.dart
@@ -18,10 +18,16 @@ class OnboardingLocalDataSourceImpl implements OnboardingLocalDataSource {
 
   @override
   Future<void> saveOnboardingState(OnboardingModel model) async {
-    if (model.selectedCurrency != null) {
-      await _preferenceManager.setString(
-          KeyConstants.selectedCurrency, jsonEncode(model.toJson()));
-    }
+    await _preferenceManager.setString(
+      KeyConstants.selectedCurrency,
+      jsonEncode(model.toJson()),
+    );
+    // if (model.selectedCurrency != null) {
+    //   await _preferenceManager.setString(
+    //     KeyConstants.selectedCurrency,
+    //     jsonEncode(model.toJson()),
+    //   );
+    // }
   }
 
   @override

--- a/lib/domain/usecases/group/ensure_default_group_exists_usecase.dart
+++ b/lib/domain/usecases/group/ensure_default_group_exists_usecase.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:fpdart/fpdart.dart';
 import 'package:injectable/injectable.dart';
 import 'package:trakli/core/error/failures/failures.dart';
@@ -27,12 +28,10 @@ class EnsureDefaultGroupExistsUseCase
         if (settings == null) {
           return const Left(Failure.notFound());
         }
-        if (settings.defaultGroup != null) {
-          return const Right(unit);
-        }
 
         // Only fetch groups if defaultGroup is not set
         final hasAnyGroup = await groupRepository.getAllGroups();
+
         return hasAnyGroup.fold(
           (failure) => Left(failure),
           (groups) async {
@@ -54,6 +53,12 @@ class EnsureDefaultGroupExistsUseCase
                 );
               });
             } else {
+              // if default group is not in the groups, then insert it
+              final defaultGroup = groups.firstWhereOrNull(
+                  (group) => group.clientId == settings.defaultGroup);
+              if (defaultGroup != null) {
+                return const Right(unit);
+              }
               // Set the first group as default and save.
               final updatedSettings =
                   settings.copyWith(defaultGroup: groups.first.clientId);

--- a/lib/presentation/app_widget.dart
+++ b/lib/presentation/app_widget.dart
@@ -398,6 +398,7 @@ class _AppViewState extends State<AppView> {
                     },
                     unauthenticated: () async {
                       getIt<SynchAppDatabase>().stopAllSync();
+                      context.read<TransactionCubit>().setCurrentGroup(null);
 
                       final entityResult = await getIt<OnboardingRepository>()
                           .getOnboardingState();

--- a/lib/presentation/auth/cubits/auth/auth_cubit.dart
+++ b/lib/presentation/auth/cubits/auth/auth_cubit.dart
@@ -76,7 +76,7 @@ class AuthCubit extends Cubit<AuthState> {
   Future<void> logout() async {
     final result = await _logoutUsecase(NoParams());
 
-    result.fold((failure) => emit(AuthState.error(failure)), (unit) {});
+    result.fold((failure) => emit(AuthState.error(failure)), (_) {});
   }
 
   @override

--- a/lib/presentation/auth/cubits/auth/auth_cubit.dart
+++ b/lib/presentation/auth/cubits/auth/auth_cubit.dart
@@ -76,7 +76,7 @@ class AuthCubit extends Cubit<AuthState> {
   Future<void> logout() async {
     final result = await _logoutUsecase(NoParams());
 
-    result.fold((failure) => emit(AuthState.error(failure)), (unit) => null);
+    result.fold((failure) => emit(AuthState.error(failure)), (unit) {});
   }
 
   @override

--- a/lib/presentation/home_screen.dart
+++ b/lib/presentation/home_screen.dart
@@ -86,8 +86,8 @@ class _HomeScreenState extends State<HomeScreen> {
     final wallets = context.watch<WalletCubit>().state.wallets;
 
     final groups = context.watch<GroupCubit>().state.groups;
-    final defaultGroupId =
-        context.watch<OnboardingCubit>().state.entity?.defaultGroup;
+    final entity = context.watch<OnboardingCubit>().state.entity;
+    final defaultGroupId = entity?.defaultGroup;
 
     final defaultGroup =
         groups.firstWhereOrNull((entity) => entity.clientId == defaultGroupId);
@@ -101,7 +101,7 @@ class _HomeScreenState extends State<HomeScreen> {
         context.watch<TransactionCubit>().state.selectedGroup;
 
     if (transactionGroup == null && selectedGroup != null) {
-      context.watch<TransactionCubit>().setCurrentGroup(selectedGroup);
+      context.read<TransactionCubit>().setCurrentGroup(selectedGroup);
     }
 
     return Scaffold(
@@ -226,8 +226,6 @@ class _HomeScreenState extends State<HomeScreen> {
 
                         if (mounted && groupEntity != null) {
                           setState(() {
-                            // group = groupEntity;
-
                             context
                                 .read<TransactionCubit>()
                                 .setCurrentGroup(groupEntity);

--- a/lib/presentation/home_screen.dart
+++ b/lib/presentation/home_screen.dart
@@ -92,17 +92,13 @@ class _HomeScreenState extends State<HomeScreen> {
     final defaultGroup =
         groups.firstWhereOrNull((entity) => entity.clientId == defaultGroupId);
 
-    final selectedGroup =
-        context.watch<TransactionCubit>().state.selectedGroup ??
-            defaultGroup ??
-            groups.firstOrNull;
-
-    final transactionGroup =
+    final currentSelectedGroup =
         context.watch<TransactionCubit>().state.selectedGroup;
 
-    if (transactionGroup == null && selectedGroup != null) {
-      context.read<TransactionCubit>().setCurrentGroup(selectedGroup);
-    }
+    final selectedGroup =
+        currentSelectedGroup ?? defaultGroup ?? groups.firstOrNull;
+
+    context.read<TransactionCubit>().setCurrentGroup(selectedGroup);
 
     return Scaffold(
       appBar: CustomAppBar(

--- a/lib/presentation/transactions/cubit/transaction_cubit.dart
+++ b/lib/presentation/transactions/cubit/transaction_cubit.dart
@@ -37,7 +37,7 @@ class TransactionCubit extends Cubit<TransactionState> {
     return super.close();
   }
 
-  Future<void> setCurrentGroup(GroupEntity groupEntity) async {
+  Future<void> setCurrentGroup(GroupEntity? groupEntity) async {
     emit(
       state.copyWith(selectedGroup: groupEntity),
     );

--- a/lib/presentation/widgets/party_display_widget.dart
+++ b/lib/presentation/widgets/party_display_widget.dart
@@ -53,8 +53,8 @@ class PartyDisplayWidget extends StatelessWidget {
           ),
           Container(
             padding: EdgeInsets.symmetric(
-              vertical: 4.h,
-              horizontal: 8.w,
+              vertical: 1.h,
+              horizontal: 1.w,
             ),
             decoration: BoxDecoration(
               color: const Color(0xFFF5F6F7),


### PR DESCRIPTION
## Description
Reset the group details after sign-out to enable the proper display of transactions after signing in from a previous sign-out. 

 Still depends on background sync reads the groups and wallets before the user completes the  onboarding process

## Type of Change
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
